### PR TITLE
Bugfix/issue 63

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OpenApiMvcServerVersion>0.10.3</OpenApiMvcServerVersion>
-    <OpenApiCSharpClientVersion>0.3.6</OpenApiCSharpClientVersion>
+    <OpenApiMvcServerVersion>0.10.4</OpenApiMvcServerVersion>
+    <OpenApiCSharpClientVersion>0.3.7</OpenApiCSharpClientVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.MsBuild/ControllerGenerator.props
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.MsBuild/ControllerGenerator.props
@@ -34,7 +34,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CleanServerOpenApiCodeGen" BeforeTargets="Clean" DependsOnTargets="_UpdateServerOpenApiCodeGenMetatdata">
+  <Target Name="CleanServerOpenApiCodeGen" BeforeTargets="Clean" DependsOnTargets="_UpdateServerOpenApiCodeGenMetatdata" Condition=" '@(OpenApiSchemaMvcServer)' != '' ">
     <ItemGroup>
       <CleanServerOpenApiCodeGen Include="%(OpenApiSchemaMvcServer.OutputPath)/**/*" />
     </ItemGroup>

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.MsBuild/ClientGenerator.props
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.MsBuild/ClientGenerator.props
@@ -34,7 +34,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CleanClientOpenApiCodeGen" BeforeTargets="Clean" DependsOnTargets="_UpdateClientOpenApiCodeGenMetatdata">
+  <Target Name="CleanClientOpenApiCodeGen" BeforeTargets="Clean" DependsOnTargets="_UpdateClientOpenApiCodeGenMetatdata" Condition=" '@(OpenApiSchemaClient)' != '' ">
     <ItemGroup>
       <CleanClientOpenApiCodeGen Include="%(OpenApiSchemaClient.OutputPath)/**/*" />
     </ItemGroup>


### PR DESCRIPTION
Adds a condition to the "Clean" subtasks to ensure at least one relevant file has been added.

If no such file has been added, before this fix it would clean `/**/*`, which would include the user's full machine.