### PR TITLE
Correct OutputDir when building from CLI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OpenApiMvcServerVersion>0.11.0</OpenApiMvcServerVersion>
+    <OpenApiMvcServerVersion>0.11.1</OpenApiMvcServerVersion>
     <OpenApiCSharpClientVersion>0.4.0</OpenApiCSharpClientVersion>
   </PropertyGroup>
 

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/PrincipleStudios.OpenApiCodegen.Server.Mvc.csproj
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/PrincipleStudios.OpenApiCodegen.Server.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">$(OpenApiMvcServerVersion)</VersionPrefix>


### PR DESCRIPTION
This puts the analyzers in the correct folder within the package.

Also, bump the patch for the server package version.