### PR TITLE
Correct generated namespaces in docker builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OpenApiMvcServerVersion>0.11.1</OpenApiMvcServerVersion>
-    <OpenApiCSharpClientVersion>0.4.0</OpenApiCSharpClientVersion>
+    <OpenApiMvcServerVersion>0.11.2</OpenApiMvcServerVersion>
+    <OpenApiCSharpClientVersion>0.4.1</OpenApiCSharpClientVersion>
   </PropertyGroup>
 
   <Import Project="Directory.Build.local.props" Condition="exists('$(MSBuildThisFileDirectory)Directory.Build.local.props')" />

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/AnalyzerReleases.Unshipped.md
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ PSAPICTRL001 | PrincipleStudios.OpenApiCodegen.Server.Mvc | Warning | Controller
 PSAPICTRL002 | PrincipleStudios.OpenApiCodegen | Warning | OpenApiGeneratorBase
 PSAPICTRL003 | PrincipleStudios.OpenApiCodegen | Info | OpenApiGeneratorBase
 PSAPICTRL004 | PrincipleStudios.OpenApiCodegen | Info | OpenApiGeneratorBase
+PSAPICTRLINFO001 | PrincipleStudios.OpenApiCodegen.Server.Mvc | Info | ControllerGenerator

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/ControllerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/ControllerGenerator.cs
@@ -21,6 +21,12 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
                                                                                                   category: "PrincipleStudios.OpenApiCodegen.Server.Mvc",
                                                                                                   DiagnosticSeverity.Warning,
                                                                                                   isEnabledByDefault: true);
+        private static readonly DiagnosticDescriptor GeneratedNamespace = new DiagnosticDescriptor(id: "PSAPICTRLINFO001",
+                                                                                                  title: "Generated Namespace",
+                                                                                                  messageFormat: "Generated Namespace: {0}",
+                                                                                                  category: "PrincipleStudios.OpenApiCodegen.Server.Mvc",
+                                                                                                  DiagnosticSeverity.Info,
+                                                                                                  isEnabledByDefault: true);
         const string sourceGroup = "OpenApiServerInterface";
         const string propNamespace = "OpenApiServerInterfaceNamespace";
         const string propConfig = "OpenApiServerConfiguration";
@@ -72,7 +78,9 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
             var documentNamespace = opt.GetAdditionalFilesMetadata(propNamespace);
             if (string.IsNullOrEmpty(documentNamespace))
                 documentNamespace = GetStandardNamespace(opt, options);
-            
+
+            context.ReportDiagnostic(Diagnostic.Create(GeneratedNamespace, Location.None, documentNamespace));
+
             result = document.BuildCSharpPathControllerSourceProvider(GetVersionInfo(), documentNamespace, options);
 
             return true;

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/ControllerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/ControllerGenerator.cs
@@ -28,8 +28,8 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
                                                                                                   DiagnosticSeverity.Info,
                                                                                                   isEnabledByDefault: true);
         const string sourceGroup = "OpenApiServerInterface";
-        const string propNamespace = "OpenApiServerInterfaceNamespace";
-        const string propConfig = "OpenApiServerConfiguration";
+        const string propNamespace = "Namespace";
+        const string propConfig = "Configuration";
 
         public ControllerGenerator() : base(sourceGroup)
         {

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/ControllerGenerator.props
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc/ControllerGenerator.props
@@ -7,27 +7,27 @@
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Identity" />
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Link" />
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemGroup" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OpenApiServerConfiguration" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OpenApiServerInterfaceNamespace" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Configuration" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Namespace" />
 
     <AvailableItemName Include="OpenApiSchemaCSharpServerOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
     <AvailableItemName Include="OpenApiSchemaMvcServer" DisplayName="Open API Schema MVC Server (OpenApiCodeGen)" />
     <Watch Include="@(OpenApiSchemaMvcServer)" Condition=" '@(OpenApiSchemaMvcServer)' != '' " />
-
-    <AdditionalFiles Include="@(OpenApiSchemaMvcServer->'%(rootdir)%(directory)%(filename)%(extension)')"
-                     SourceItemGroup="OpenApiServerInterface"
-                     OpenApiServerConfiguration="@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')"
-                     Visible="false"
-                     Condition=" '@(OpenApiSchemaMvcServer)' != '' " />
   </ItemGroup>
 
   <Target Name="_InjectAdditionalFilesForOpenApiSchemaMvcServer" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
-      <AdditionalFiles Include="@(OpenApiSchemaMvcServer->'%(rootdir)%(directory)%(filename)%(extension)')"
-                       SourceItemGroup="OpenApiServerInterface"
-                       OpenApiServerConfiguration="@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')"
-                       Visible="false"
-                       Condition=" '@(OpenApiSchemaMvcServer)' != '' " />
+      <AdditionalFiles Include="@(OpenApiSchemaMvcServer)">
+        <SourceItemGroup>OpenApiServerInterface</SourceItemGroup>
+        <WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+        <WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+        <Namespace Condition=" '%(OpenApiSchemaMvcServer.Namespace)' != '' ">%(OpenApiSchemaMvcServer.Namespace)</Namespace>
+        <Configuration Condition=" '%(OpenApiSchemaMvcServer.Configuration)' != '' ">%(OpenApiSchemaMvcServer.Configuration)</Configuration>
+        <Configuration Condition=" '%(OpenApiSchemaMvcServer.Configuration)' == '' ">@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')</Configuration>
+      </AdditionalFiles>
+      <AdditionalFiles>
+        <Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' and '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
+      </AdditionalFiles>
     </ItemGroup>
   </Target>
 </Project>

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client/ClientGenerator.cs
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client/ClientGenerator.cs
@@ -29,8 +29,8 @@ namespace PrincipleStudios.OpenApiCodegen.Client
                                                                                                   DiagnosticSeverity.Info,
                                                                                                   isEnabledByDefault: true);
         const string sourceGroup = "OpenApiClientInterface";
-        const string propNamespace = "OpenApiClientInterfaceNamespace";
-        const string propConfig = "OpenApiClientConfiguration";
+        const string propNamespace = "Namespace";
+        const string propConfig = "Configuration";
 
         public ClientGenerator() : base(sourceGroup)
         {

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client/ClientGenerator.cs
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client/ClientGenerator.cs
@@ -21,6 +21,13 @@ namespace PrincipleStudios.OpenApiCodegen.Client
                                                                                                   category: "PrincipleStudios.OpenApiCodegen.Client",
                                                                                                   DiagnosticSeverity.Warning,
                                                                                                   isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor GeneratedNamespace = new DiagnosticDescriptor(id: "PSAPICLNTINFO001",
+                                                                                                  title: "Generated Namespace",
+                                                                                                  messageFormat: "Generated Namespace: {0}",
+                                                                                                  category: "PrincipleStudios.OpenApiCodegen.Client",
+                                                                                                  DiagnosticSeverity.Info,
+                                                                                                  isEnabledByDefault: true);
         const string sourceGroup = "OpenApiClientInterface";
         const string propNamespace = "OpenApiClientInterfaceNamespace";
         const string propConfig = "OpenApiClientConfiguration";
@@ -72,7 +79,9 @@ namespace PrincipleStudios.OpenApiCodegen.Client
             var documentNamespace = opt.GetAdditionalFilesMetadata(propNamespace);
             if (string.IsNullOrEmpty(documentNamespace))
                 documentNamespace = GetStandardNamespace(opt, options);
-            
+
+            context.ReportDiagnostic(Diagnostic.Create(GeneratedNamespace, Location.None, documentNamespace));
+
             result = document.BuildCSharpClientSourceProvider(GetVersionInfo(), documentNamespace, options);
 
             return true;

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client/ClientGenerator.props
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client/ClientGenerator.props
@@ -7,27 +7,27 @@
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Identity" />
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Link" />
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemGroup" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OpenApiClientConfiguration" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OpenApiClientInterfaceNamespace" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Configuration" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Namespace" />
 
     <AvailableItemName Include="OpenApiSchemaCSharpClientOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
     <AvailableItemName Include="OpenApiSchemaClient" DisplayName="Open API Schema Client (OpenApiCodeGen)" />
     <Watch Include="@(OpenApiSchemaClient);@(OpenApiSchemaCSharpOptions)" Condition=" '@(OpenApiSchemaClient)' != '' " />
-
-    <AdditionalFiles Include="@(OpenApiSchemaClient->'%(rootdir)%(directory)%(filename)%(extension)')"
-                     SourceItemGroup="OpenApiSchemaInterface"
-                     OpenApiClientConfiguration="@(OpenApiSchemaCSharpClientOptions->'%(FullPath)')"
-                     Visible="false"
-                     Condition=" '@(OpenApiSchemaClient)' != '' " />
   </ItemGroup>
 
   <Target Name="_InjectAdditionalFilesForOpenApiSchemaClient" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
-      <AdditionalFiles Include="@(OpenApiSchemaClient->'%(rootdir)%(directory)%(filename)%(extension)')"
-                       SourceItemGroup="OpenApiClientInterface"
-                       OpenApiClientConfiguration="@(OpenApiSchemaCSharpClientOptions->'%(FullPath)')"
-                       Visible="false"
-                       Condition=" '@(OpenApiSchemaClient)' != '' " />
+      <AdditionalFiles Include="@(OpenApiSchemaClient)">
+        <SourceItemGroup>OpenApiClientInterface</SourceItemGroup>
+        <WorkingOutputPath Condition=" '%(OpenApiSchemaClient.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaClient.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+        <WorkingOutputPath Condition=" '%(OpenApiSchemaClient.Link)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaClient.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+        <Namespace Condition=" '%(OpenApiSchemaClient.Namespace)' != '' ">%(OpenApiSchemaClient.Namespace)</Namespace>
+        <Configuration Condition=" '%(OpenApiSchemaClient.Configuration)' != '' ">%(OpenApiSchemaClient.Configuration)</Configuration>
+        <Configuration Condition=" '%(OpenApiSchemaClient.Configuration)' == '' ">@(OpenApiSchemaCSharpClientOptions->'%(FullPath)')</Configuration>
+      </AdditionalFiles>
+      <AdditionalFiles>
+        <Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' and '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
+      </AdditionalFiles>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Properties, such as Namespace and Link, were not being passed through from original item types to the `AdditionalFiles` items. This corrects that and normalizes property names.