### PR TITLE
Fix reg ex pattern matching behavior for OpenAPI and .NET compatibility

### DIFF
--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/templates/controller.handlebars
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/templates/controller.handlebars
@@ -48,7 +48,7 @@ namespace {{packageName}}
             }}{{#if isFormParam}}global::Microsoft.AspNetCore.Mvc.FromForm(Name = "{{rawName}}"){{/if}}{{!
             }}{{#if isHeaderParam}}global::Microsoft.AspNetCore.Mvc.FromHeader(Name = "{{rawName}}"){{/if}}{{!
             }}{{#if required}}, global::System.ComponentModel.DataAnnotations.Required{{/if}}{{!
-            }}{{#if pattern}}, global::System.ComponentModel.DataAnnotations.RegularExpression(@"{{{escapeverbatimstring pattern}}}"){{/if}}{{!
+            }}{{#if pattern}}, global::System.ComponentModel.DataAnnotations.RegularExpression(@".*{{{escapeverbatimstring pattern}}}.*"){{/if}}{{!
             }}{{#if HasMinLength}}, global::System.ComponentModel.DataAnnotations.MinLength({{minLength}}){{/if}}{{!
             }}{{#if HasMaxLength}}, global::System.ComponentModel.DataAnnotations.MaxLength({{maxLength}}){{/if}}{{!
             }}{{#if HasMinimum}}{{#if HasMaximum}}, global::System.ComponentModel.DataAnnotations.Range({{minimum}}, {{maximum}}){{/if}}{{/if}}{{!

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/RegexEscapeYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/RegexEscapeYamlShould.cs
@@ -11,7 +11,7 @@ public class RegexEscapeYamlShould
     [Theory]
     [InlineData(false, "nope")]
     [InlineData(true, "\"foo\"")]
-    [InlineData(true, "prefix \"foo\" suffix")] // See #98
+    [InlineData(true, "prefix \"foo\" suffix")] 
     public Task Handle_validation_of_regex_parameters(bool expectedIsValid, string content) =>
         TestSingleRequest<RegexEscape.ControllerBase.TestForRegexActionResult, string>(new(
             RegexEscape.ControllerBase.TestForRegexActionResult.Unsafe(new Microsoft.AspNetCore.Mvc.BadRequestResult()),

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/RegexEscapeYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/RegexEscapeYamlShould.cs
@@ -11,7 +11,7 @@ public class RegexEscapeYamlShould
     [Theory]
     [InlineData(false, "nope")]
     [InlineData(true, "\"foo\"")]
-    // [InlineData(true, "prefix \"foo\" suffix")] // See #98
+    [InlineData(true, "prefix \"foo\" suffix")] // See #98
     public Task Handle_validation_of_regex_parameters(bool expectedIsValid, string content) =>
         TestSingleRequest<RegexEscape.ControllerBase.TestForRegexActionResult, string>(new(
             RegexEscape.ControllerBase.TestForRegexActionResult.Unsafe(new Microsoft.AspNetCore.Mvc.BadRequestResult()),


### PR DESCRIPTION
Add .* to the beginning and end of the reg ex pattern to ensure that OpenAPI and .NET handle pattern matching consistently. OpenAPI expects a proper regular expression, while .NET matches the entire string. I generated a test application and confirmed that the reg ex attribute was correctly applied.