### PR TITLE
Allow C# MVC to have a prefix per OpenAPI file

### DIFF
--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/CSharpControllerTransformer.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/CSharpControllerTransformer.cs
@@ -16,11 +16,11 @@ namespace PrincipleStudios.OpenApi.CSharp
         private readonly ISchemaSourceResolver<InlineDataType> csharpSchemaResolver;
         private readonly OpenApiDocument document;
         private readonly string baseNamespace;
-        private readonly CSharpSchemaOptions options;
+        private readonly CSharpServerSchemaOptions options;
         private readonly string versionInfo;
         private readonly HandlebarsFactory handlebarsFactory;
 
-        public CSharpControllerTransformer(ISchemaSourceResolver<InlineDataType> csharpSchemaResolver, OpenApiDocument document, string baseNamespace, CSharpSchemaOptions options, string versionInfo, HandlebarsFactory handlebarsFactory)
+        public CSharpControllerTransformer(ISchemaSourceResolver<InlineDataType> csharpSchemaResolver, OpenApiDocument document, string baseNamespace, CSharpServerSchemaOptions options, string versionInfo, HandlebarsFactory handlebarsFactory)
         {
             this.csharpSchemaResolver = csharpSchemaResolver;
             this.document = document;

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/CSharpServerSchemaOptions.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/CSharpServerSchemaOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PrincipleStudios.OpenApi.CSharp;
+
+public class CSharpServerSchemaOptions : CSharpSchemaOptions
+{
+    public string PathPrefix { get; set; } = "";
+}

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/ControllerOperationVisitor.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/ControllerOperationVisitor.cs
@@ -47,6 +47,9 @@ namespace PrincipleStudios.OpenApi.CSharp
             var path = context.Where(c => c.Element is OpenApiPathItem).Last().Key;
             if (path == null)
                 throw new ArgumentException("Context is not initialized properly - key expected for path items", nameof(context));
+            if (options.PathPrefix is { Length: > 1 })
+                path = options.PathPrefix + "/" + path.TrimStart('/');
+            path = "/" + path.TrimStart('/');
 
             var builder = new OperationBuilder(operation);
 

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/ControllerOperationVisitor.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/ControllerOperationVisitor.cs
@@ -10,7 +10,7 @@ namespace PrincipleStudios.OpenApi.CSharp
     class ControllerOperationVisitor : OpenApiDocumentVisitor<ControllerOperationVisitor.Argument>
     {
         private readonly ISchemaSourceResolver<InlineDataType> csharpSchemaResolver;
-        private readonly CSharpSchemaOptions options;
+        private readonly CSharpServerSchemaOptions options;
         private readonly string controllerClassName;
 
         public record Argument(OpenApiTransformDiagnostic Diagnostic, RegisterControllerOperation RegisterControllerOperation, OperationBuilder? Builder = null);
@@ -32,7 +32,7 @@ namespace PrincipleStudios.OpenApi.CSharp
             public OpenApiOperation Operation { get; }
         }
 
-        public ControllerOperationVisitor(ISchemaSourceResolver<InlineDataType> csharpSchemaResolver, CSharpSchemaOptions options, string controllerClassName)
+        public ControllerOperationVisitor(ISchemaSourceResolver<InlineDataType> csharpSchemaResolver, CSharpServerSchemaOptions options, string controllerClassName)
         {
             this.csharpSchemaResolver = csharpSchemaResolver;
             this.options = options;

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/OpenApiMvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/OpenApiMvcServerGenerator.cs
@@ -160,7 +160,7 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
             return true;
         }
 
-        private CSharpSchemaOptions LoadOptions(string? optionsFiles)
+        private CSharpServerSchemaOptions LoadOptions(string? optionsFiles)
         {
             using var defaultJsonStream = CSharpSchemaOptions.GetDefaultOptionsJson();
             var builder = new ConfigurationBuilder();
@@ -175,7 +175,7 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
                     }
                 }
             }
-            var result = builder.Build().Get<CSharpSchemaOptions>();
+            var result = builder.Build().Get<CSharpServerSchemaOptions>();
             return result;
         }
 

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/PathControllerTransformerFactory.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/PathControllerTransformerFactory.cs
@@ -6,7 +6,7 @@ namespace PrincipleStudios.OpenApi.CSharp
 {
     public static class PathControllerTransformerFactory
     {
-        public static ISourceProvider BuildCSharpPathControllerSourceProvider(this OpenApiDocument document, string versionInfo, string? documentNamespace, CSharpSchemaOptions options)
+        public static ISourceProvider BuildCSharpPathControllerSourceProvider(this OpenApiDocument document, string versionInfo, string? documentNamespace, CSharpServerSchemaOptions options)
         {
             ISourceProvider? result;
             var handlebarsFactory = new HandlebarsFactory(ControllerHandlebarsTemplateProcess.CreateHandlebars);

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/templates/controller.handlebars
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Analyzers/templates/controller.handlebars
@@ -27,7 +27,7 @@ namespace {{packageName}}
         /// </remarks>{{/if}}{{#each requestBody.allParams}}
         /// <param name="{{paramName}}">{{description}}</param>{{/each}}
         [global::Microsoft.AspNetCore.Mvc.Http{{operation.httpMethod}}]
-        [global::Microsoft.AspNetCore.Mvc.Route("{{{operation.basePathWithoutHost}}}{{{operation.path}}}")]{{#if requestBody.requestBodyType}}
+        [global::Microsoft.AspNetCore.Mvc.Route("{{{operation.path}}}")]{{#if requestBody.requestBodyType}}
         [global::Microsoft.AspNetCore.Mvc.Consumes("{{{requestBody.requestBodyType}}}")]{{/if}}{{!
         }}{{#if operation.responses.defaultResponse}}
         // {{operation.responses.defaultResponse.description}}

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Cli/Program.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Cli/Program.cs
@@ -11,11 +11,13 @@ using System.IO;
 var openApiFilePath = args[0];
 var csharpNamespace = args[1];
 var outputFolder = args[2];
+var pathPrefix = args.Length > 3 ? args[3] : "";
 
-Console.WriteLine($"Hello:");
+Console.WriteLine($"Generating with the following settings:");
 Console.WriteLine($"  OpenAPI: {openApiFilePath}");
 Console.WriteLine($"  C# Namespace: {csharpNamespace}");
 Console.WriteLine($"  Output folder: {outputFolder}");
+Console.WriteLine($"  Path prefix: {pathPrefix}");
 
 // empty the directory and then recreate it
 if (Directory.Exists(outputFolder))
@@ -24,6 +26,7 @@ Directory.CreateDirectory(outputFolder);
 
 var document = GetDocument(openApiFilePath);
 var options = LoadOptions();
+options.PathPrefix = pathPrefix;
 
 var transformer = document.BuildCSharpPathControllerSourceProvider("", csharpNamespace, options);
 OpenApiTransformDiagnostic diagnostic = new();

--- a/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Cli/Program.cs
+++ b/generators/dotnetcore-server-interfaces/PrincipleStudios.OpenApiCodegen.Server.Mvc.Cli/Program.cs
@@ -43,12 +43,12 @@ Microsoft.OpenApi.Models.OpenApiDocument GetDocument(string path)
     var reader = new Microsoft.OpenApi.Readers.OpenApiStreamReader();
     return reader.Read(documentStream, out var openApiDiagnostic);
 }
-CSharpSchemaOptions LoadOptions(Action<IConfigurationBuilder>? configureBuilder = null)
+CSharpServerSchemaOptions LoadOptions(Action<IConfigurationBuilder>? configureBuilder = null)
 {
     using var defaultJsonStream = CSharpSchemaOptions.GetDefaultOptionsJson();
     var builder = new ConfigurationBuilder();
     builder.AddYamlStream(defaultJsonStream);
     configureBuilder?.Invoke(builder);
-    var result = builder.Build().Get<CSharpSchemaOptions>();
+    var result = builder.Build().Get<CSharpServerSchemaOptions>();
     return result;
 }

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.Analyzers/OperationVisitor.cs
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.Analyzers/OperationVisitor.cs
@@ -47,6 +47,9 @@ namespace PrincipleStudios.OpenApi.CSharp
             var path = context.Where(c => c.Element is OpenApiPathItem).Last().Key;
             if (path == null)
                 throw new ArgumentException("Context is not initialized properly - key expected for path items", nameof(context));
+            if (options.PathPrefix is { Length: > 1 })
+                path = options.PathPrefix + "/" + path.TrimStart('/');
+            path = "/" + path.TrimStart('/');
 
             var builder = new OperationBuilder(operation);
 

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.Analyzers/OperationVisitor.cs
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.Analyzers/OperationVisitor.cs
@@ -47,9 +47,6 @@ namespace PrincipleStudios.OpenApi.CSharp
             var path = context.Where(c => c.Element is OpenApiPathItem).Last().Key;
             if (path == null)
                 throw new ArgumentException("Context is not initialized properly - key expected for path items", nameof(context));
-            if (options.PathPrefix is { Length: > 1 })
-                path = options.PathPrefix + "/" + path.TrimStart('/');
-            path = "/" + path.TrimStart('/');
 
             var builder = new OperationBuilder(operation);
 

--- a/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.Analyzers/templates/client.handlebars
+++ b/generators/dotnetstandard-client/PrincipleStudios.OpenApiCodegen.Client.Analyzers/templates/client.handlebars
@@ -46,7 +46,9 @@ namespace {{packageName}}
                     + {{#if operation.hasQueryStringEmbedded}}"&"{{else}}"?"{{/if}} + query.ToString(),
                     global::System.UriKind.Relative));
 {{else}}
-            var requestMessage = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.{{{operation.httpMethod}}}, "{{{operation.path}}}"{{#each requestBody.allParams}}{{#if isPathParam}}
+            var requestMessage = new global::System.Net.Http.HttpRequestMessage(
+                global::System.Net.Http.HttpMethod.{{{operation.httpMethod}}},
+                "{{{operation.path}}}"{{#each requestBody.allParams}}{{#if isPathParam}}
                         .Replace("{" + "{{rawName}}" + "}", global::System.Web.HttpUtility.UrlEncode({{#if required}}{{paramName}}{{else}}global::PrincipleStudios.OpenApiCodegen.Json.Extensions.Optional.GetValueOrThrow({{paramName}}){{/if}}.ToString())){{/if}}{{/each}});
 {{/if}}
 {{#if requestBody.isForm}}

--- a/lib/PrincipleStudios.OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/PrincipleStudios.OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -12,7 +12,6 @@ namespace PrincipleStudios.OpenApi.CSharp
         public string MapType { get; set; } = "global::System.Collections.Generic.Dictionary<string, {}>";
         public string ArrayType { get; set; } = "global::System.Collections.Generic.IEnumerable<{}>";
         public string FallbackType { get; set; } = "object";
-        public string PathPrefix { get; set; } = "";
         public Dictionary<string, OpenApiTypeFormats> Types { get; set; } = new();
 
         internal string Find(string type, string? format)

--- a/lib/PrincipleStudios.OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/PrincipleStudios.OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -12,6 +12,7 @@ namespace PrincipleStudios.OpenApi.CSharp
         public string MapType { get; set; } = "global::System.Collections.Generic.Dictionary<string, {}>";
         public string ArrayType { get; set; } = "global::System.Collections.Generic.IEnumerable<{}>";
         public string FallbackType { get; set; } = "object";
+        public string PathPrefix { get; set; } = "";
         public Dictionary<string, OpenApiTypeFormats> Types { get; set; } = new();
 
         internal string Find(string type, string? format)

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/DynamicCompilation.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/DynamicCompilation.cs
@@ -35,10 +35,11 @@ namespace PrincipleStudios.OpenApiCodegen.Client.CSharp
                 typeof(PrincipleStudios.OpenApiCodegen.Json.Extensions.JsonStringEnumPropertyNameConverter).Assembly.Location,
         };
 
-        public static byte[] GetGeneratedLibrary(string documentName)
+        public static byte[] GetGeneratedLibrary(string documentName, Action<CSharpSchemaOptions>? configureOptions = null)
         {
             var document = GetDocument(documentName);
             var options = LoadOptions();
+            configureOptions?.Invoke(options);
 
             var transformer = document.BuildCSharpClientSourceProvider("", "PS.Controller", options);
             OpenApiTransformDiagnostic diagnostic = new();

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/HttpRequestMessageFactoriesShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/HttpRequestMessageFactoriesShould.cs
@@ -47,16 +47,6 @@ public class HttpRequestMessageFactoriesShould : IClassFixture<TempDirectory>
     }
 
     [Fact]
-    public async Task AllowOverridesOfPrefixes()
-    {
-        var actualMessage = await GetRequestMessage("dictionary-ref.yaml", @"LookupRecord(lookupRecordBody: new() { [""key1""] = ""value1"", [""key\"":2""] = ""value\n2"" })",
-            options => options.PathPrefix = "foobar");
-
-        Assert.Equal("POST", actualMessage.Method.Method);
-        Assert.Equal("foobar/address", actualMessage.RequestUri?.OriginalString);
-    }
-
-    [Fact]
     public async Task SerializeEnumerations()
     {
         var actualMessage = await GetRequestMessage("enum.yaml", @"PlayRockPaperScissors(playRockPaperScissorsBody: new(Player1: Option.Rock, Player2: Option.Paper))");

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/HeadersYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/HeadersYamlShould.cs
@@ -22,7 +22,7 @@ public class HeadersYamlShould
 
         var result = await commonDirectory.ConvertRequest("headers.yaml", "getInfo", new { xData = headerData });
 
-        var token = AssertRequestSuccess(result, "GET", "/headers/info");
+        var token = AssertRequestSuccess(result, "GET", "/info");
         Assert.Equal("foobar", token["headers"]?["X-Data"]?.ToObject<string>());
     }
 

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/OptionsHelpers.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/OptionsHelpers.cs
@@ -8,13 +8,14 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
 {
     public static class OptionsHelpers
     {
-        public static CSharpSchemaOptions LoadOptions(Action<IConfigurationBuilder>? configureBuilder = null)
+        public static CSharpServerSchemaOptions LoadOptions(Action<IConfigurationBuilder>? configureBuilder = null)
         {
             using var defaultJsonStream = CSharpSchemaOptions.GetDefaultOptionsJson();
             var builder = new ConfigurationBuilder();
             builder.AddYamlStream(defaultJsonStream);
             configureBuilder?.Invoke(builder);
-            var result = builder.Build().Get<CSharpSchemaOptions>();
+            var result = builder.Build().Get<CSharpServerSchemaOptions>();
+            if (result == null) throw new InvalidOperationException("Could not load default test");
             return result;
         }
     }

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/AllOfYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/AllOfYamlShould.cs
@@ -12,7 +12,7 @@ public class AllOfYamlShould
     public Task HandleAllOfResponses() =>
         TestSingleRequest<AllOf.ContactControllerBase.GetContactActionResult>(new(
             AllOf.ContactControllerBase.GetContactActionResult.Ok(new(FirstName: "John", LastName: "Doe", Id: "john-doe-123")),
-            client => client.GetAsync("/contact")
+            client => client.GetAsync("/all-of/contact")
         )
         {
             AssertResponseMessage = VerifyResponse(200, new { firstName = "John", lastName = "Doe", id = "john-doe-123" }),

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/ControllerExtensionsYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/ControllerExtensionsYamlShould.cs
@@ -11,7 +11,7 @@ public class ControllerExtensionsYamlShould
     public Task DecodeBase64EncodedQueryData() =>
         TestSingleRequest<ControllerExtensions.InformationControllerBase.GetInfoActionResult>(new(
             ControllerExtensions.InformationControllerBase.GetInfoActionResult.Ok("SomeData"),
-            client => client.GetAsync("/api/info")
+            client => client.GetAsync("/controller-extensions/api/info")
         )
         {
             AssertResponseMessage = VerifyResponse(200, "SomeData"),

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/EnumYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/EnumYamlShould.cs
@@ -12,7 +12,7 @@ public class EnumYamlShould
     public Task Handle_enum_requests_and_responses() =>
         TestSingleRequest<Enum.RockPaperScissorsControllerBase.PlayRockPaperScissorsActionResult, Enum.PlayRockPaperScissorsRequest>(new(
             Enum.RockPaperScissorsControllerBase.PlayRockPaperScissorsActionResult.Ok(Enum.PlayRockPaperScissorsResponse.Player1),
-            client => client.PostAsync("/rock-paper-scissors", JsonContent.Create(new { player1 = "rock", player2 = "scissors" }))
+            client => client.PostAsync("/enum/rock-paper-scissors", JsonContent.Create(new { player1 = "rock", player2 = "scissors" }))
         )
         {
             AssertRequest = (controller, request) =>
@@ -27,7 +27,7 @@ public class EnumYamlShould
     public Task Handle_invalid_enum_requests_and_give_400_response() =>
         TestSingleRequest<Enum.RockPaperScissorsControllerBase.PlayRockPaperScissorsActionResult, Enum.PlayRockPaperScissorsRequest>(new(
             Enum.RockPaperScissorsControllerBase.PlayRockPaperScissorsActionResult.Unsafe(new Microsoft.AspNetCore.Mvc.BadRequestResult()),
-            client => client.PostAsync("/rock-paper-scissors", JsonContent.Create(new { player1 = "spock", player2 = "lizard" }))
+            client => client.PostAsync("/enum/rock-paper-scissors", JsonContent.Create(new { player1 = "spock", player2 = "lizard" }))
         )
         {
             AssertRequest = (controller, request) =>

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/FormYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/FormYamlShould.cs
@@ -11,8 +11,8 @@ public class FormYamlShould
 {
     [Fact]
     public Task Handle_FormUrlEncodedContent_requests() =>
-        TestSingleRequest<Form.FormBasicControllerBase.PostBasicFormActionResult, (string Name, string Tag, bool HasIdTag)>(new(
-            Form.FormBasicControllerBase.PostBasicFormActionResult.Ok(17),
+        TestSingleRequest<Form.BasicControllerBase.PostBasicFormActionResult, (string Name, string Tag, bool HasIdTag)>(new(
+            Form.BasicControllerBase.PostBasicFormActionResult.Ok(17),
             client => client.PostAsync("/form/basic", new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["name"] = "Fido",

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/HeadersYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/HeadersYamlShould.cs
@@ -14,8 +14,8 @@ public class HeadersYamlShould
 {
     [Fact]
     public Task HandleHeaderRequestsAndResponses() =>
-        TestSingleRequest<Headers.HeadersInfoControllerBase.GetInfoActionResult, byte[]>(new(
-            Headers.HeadersInfoControllerBase.GetInfoActionResult.Ok(new() { ["foo"] = "bar" }, "some-header-data"),
+        TestSingleRequest<Headers.InfoControllerBase.GetInfoActionResult, byte[]>(new(
+            Headers.InfoControllerBase.GetInfoActionResult.Ok(new() { ["foo"] = "bar" }, "some-header-data"),
             client => client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/headers/info")
             {
                 Headers =
@@ -42,8 +42,8 @@ public class HeadersYamlShould
 
     [Fact]
     public Task HandleRedirectionResponses() =>
-        TestSingleRequest<Headers.HeadersRedirectControllerBase._RedirectActionResult, byte[]>(new(
-            Headers.HeadersRedirectControllerBase._RedirectActionResult.Redirect("https://google.com"),
+        TestSingleRequest<Headers.RedirectControllerBase._RedirectActionResult, byte[]>(new(
+            Headers.RedirectControllerBase._RedirectActionResult.Redirect("https://google.com"),
             client => client.GetAsync("/headers/redirect")
         )
         {

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/OauthYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/OauthYamlShould.cs
@@ -15,8 +15,8 @@ public class OauthYamlShould
 {
     [Fact]
     public Task Handle_anonymous_requests() =>
-        TestSingleRequest<OAuth.OauthInfoControllerBase.GetInfoActionResult>(new(
-            OAuth.OauthInfoControllerBase.GetInfoActionResult.Ok("baadf00d"),
+        TestSingleRequest<OAuth.InfoControllerBase.GetInfoActionResult>(new(
+            OAuth.InfoControllerBase.GetInfoActionResult.Ok("baadf00d"),
             client => client.GetAsync("/oauth/info")
         )
         {
@@ -30,8 +30,8 @@ public class OauthYamlShould
 
     [Fact]
     public Task Handle_api_key_requests() =>
-        TestSingleRequest<OAuth.OauthInfoControllerBase.GetInfoActionResult>(new(
-            OAuth.OauthInfoControllerBase.GetInfoActionResult.Ok("baadf00d"),
+        TestSingleRequest<OAuth.InfoControllerBase.GetInfoActionResult>(new(
+            OAuth.InfoControllerBase.GetInfoActionResult.Ok("baadf00d"),
             client => client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/oauth/info")
             {
                 Headers =
@@ -64,8 +64,8 @@ public class OauthYamlShould
     [Fact]
     public Task Handles_multiple_authorization_schemes() =>
 
-        TestSingleRequest<OAuth.OauthAddressControllerBase.GetAddressActionResult>(new(
-            OAuth.OauthAddressControllerBase.GetAddressActionResult.Ok("baadf00d"),
+        TestSingleRequest<OAuth.AddressControllerBase.GetAddressActionResult>(new(
+            OAuth.AddressControllerBase.GetAddressActionResult.Ok("baadf00d"),
             client => client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/oauth/address")
             {
                 Headers =

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/RegexEscapeYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/RegexEscapeYamlShould.cs
@@ -15,7 +15,7 @@ public class RegexEscapeYamlShould
     public Task Handle_validation_of_regex_parameters(bool expectedIsValid, string content) =>
         TestSingleRequest<RegexEscape.ControllerBase.TestForRegexActionResult, string>(new(
             RegexEscape.ControllerBase.TestForRegexActionResult.Unsafe(new Microsoft.AspNetCore.Mvc.BadRequestResult()),
-            client => client.PostAsync("/", JsonContent.Create(content))
+            client => client.PostAsync("/regex-escape/", JsonContent.Create(content))
         )
         {
             AssertRequest = (controller, request) =>

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/ValidationMinMaxYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/ValidationMinMaxYamlShould.cs
@@ -13,8 +13,8 @@ public class ValidationMinMaxYamlShould
     [InlineData(true, 1)]
     [InlineData(true, 7654L)]
     public Task Handle_validation_of_integer_parameters(bool expectedIsValid, long value) =>
-        TestSingleRequest<ValidationMinMax.ValidationMinMaxColorsControllerBase.GetColorActionResult, long>(new(
-            ValidationMinMax.ValidationMinMaxColorsControllerBase.GetColorActionResult.Ok("red"),
+        TestSingleRequest<ValidationMinMax.ColorsControllerBase.GetColorActionResult, long>(new(
+            ValidationMinMax.ColorsControllerBase.GetColorActionResult.Ok("red"),
             client => client.GetAsync($"/validation-min-max/colors?id={value}")
         )
         {

--- a/lib/TestApp/Form/Controllers.cs
+++ b/lib/TestApp/Form/Controllers.cs
@@ -2,7 +2,7 @@
 
 namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.Form;
 
-public class FormBasicController : FormBasicControllerBase
+public class FormBasicController : BasicControllerBase
 {
     protected override Task<PostBasicFormActionResult> PostBasicForm(string name, string tag, bool hasIdTag)
     {

--- a/lib/TestApp/Headers/Controllers.cs
+++ b/lib/TestApp/Headers/Controllers.cs
@@ -1,6 +1,6 @@
 ﻿namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.Headers;
 
-public class InfoController : HeadersInfoControllerBase
+public class InfoController : InfoControllerBase
 {
     protected override Task<GetInfoActionResult> GetInfo(byte[] xData)
     {
@@ -9,7 +9,7 @@ public class InfoController : HeadersInfoControllerBase
     }
 }
 
-public class RedirectController : HeadersRedirectControllerBase
+public class RedirectController : RedirectControllerBase
 {
     protected override Task<_RedirectActionResult> Redirect()
     {

--- a/lib/TestApp/OAuth/Controllers.cs
+++ b/lib/TestApp/OAuth/Controllers.cs
@@ -1,6 +1,6 @@
 ﻿namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.OAuth;
 
-public class InfoController : OauthInfoControllerBase
+public class InfoController : InfoControllerBase
 {
     protected override Task<GetInfoActionResult> GetInfo()
     {
@@ -10,7 +10,7 @@ public class InfoController : OauthInfoControllerBase
 
 }
 
-public class AddressController : OauthAddressControllerBase
+public class AddressController : AddressControllerBase
 {
     protected override Task<GetAddressActionResult> GetAddress()
     {

--- a/lib/TestApp/PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\all-of.yaml" Link="AllOf\all-of.yaml" Key="AllOf" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\enum.yaml" Link="Enum\enum.yaml" Key="Enum" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\controller-extension.yaml" Link="ControllerExtensions\controller-extension.yaml" Key="ControllerExtensions" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\validation-min-max.yaml" Link="ValidationMinMax\validation-min-max.yaml" Key="ValidationMinMax" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\regex-escape.yaml" Link="RegexEscape\regex-escape.yaml" Key="RegexEscape" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\headers.yaml" Link="Headers\headers.yaml" Key="Headers" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\oauth.yaml" Link="OAuth\oauth.yaml" Key="OAuth" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\form.yaml" Link="Form\form.yaml" Key="Form" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\all-of.yaml" Link="AllOf\all-of.yaml" Key="AllOf" PathPrefix="/all-of" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\enum.yaml" Link="Enum\enum.yaml" Key="Enum" PathPrefix="/enum" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\controller-extension.yaml" Link="ControllerExtensions\controller-extension.yaml" Key="ControllerExtensions" PathPrefix="/controller-extensions" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\validation-min-max.yaml" Link="ValidationMinMax\validation-min-max.yaml" Key="ValidationMinMax" PathPrefix="/validation-min-max" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\regex-escape.yaml" Link="RegexEscape\regex-escape.yaml" Key="RegexEscape" PathPrefix="/regex-escape" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\headers.yaml" Link="Headers\headers.yaml" Key="Headers" PathPrefix="/headers" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\oauth.yaml" Link="OAuth\oauth.yaml" Key="OAuth" PathPrefix="/oauth" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\form.yaml" Link="Form\form.yaml" Key="Form" PathPrefix="/form" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,6 +37,7 @@
         <WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
         <WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
         <Namespace Condition=" '%(OpenApiSchemaMvcServer.Namespace)' != '' ">%(OpenApiSchemaMvcServer.Namespace)</Namespace>
+        <PathPrefix>%(OpenApiSchemaMvcServer.PathPrefix)</PathPrefix>
         <Key>%(OpenApiSchemaMvcServer.Key)</Key>
       </CodegenCliFiles>
       <CodegenCliFiles>
@@ -52,7 +53,7 @@
           <CodegenCliPath>%(CodegenCli.Identity)</CodegenCliPath>
         </PropertyGroup>
 
-		<Exec Command="dotnet &quot;$(CodegenCliPath)&quot; &quot;%(CodegenCliFiles.FullPath)&quot; &quot;%(CodegenCliFiles.Namespace)&quot; &quot;$(MSBuildProjectDirectory)/generated/%(CodegenCliFiles.Key)&quot;" Outputs="CodegenOutputs" />
+		<Exec Command="dotnet &quot;$(CodegenCliPath)&quot; &quot;%(CodegenCliFiles.FullPath)&quot; &quot;%(CodegenCliFiles.Namespace)&quot; &quot;$(MSBuildProjectDirectory)/generated/%(CodegenCliFiles.Key)&quot; &quot;%(CodegenCliFiles.PathPrefix)&quot;" Outputs="CodegenOutputs" />
 		<Touch Files="$(MSBuildProjectDirectory)/generated/%(CodegenCliFiles.Key)/_._" AlwaysCreate="true" />
 	</Target>
 

--- a/lib/TestApp/ValidationMinMax/ColorsController.cs
+++ b/lib/TestApp/ValidationMinMax/ColorsController.cs
@@ -1,6 +1,6 @@
 namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.ValidationMinMax;
 
-public class ColorsController : ValidationMinMaxColorsControllerBase
+public class ColorsController : ColorsControllerBase
 {
     protected override Task<GetColorActionResult> GetColor(long id)
     {

--- a/schemas/form.yaml
+++ b/schemas/form.yaml
@@ -4,7 +4,7 @@ info:
   title: Form Sample
   description: A sample API that uses form-encoded requests
 paths:
-  /form/basic:
+  /basic:
     post:
       description: Posts a simple form
       operationId: postBasicForm

--- a/schemas/headers.yaml
+++ b/schemas/headers.yaml
@@ -4,7 +4,7 @@ info:
   title: Headers Sample
   description: A sample API that demonstrates header parameters/responses
 paths:
-  /headers/info:
+  /info:
     get:
       operationId: getInfo
       parameters:
@@ -47,7 +47,7 @@ paths:
               description: error diagnostic
               schema:
                 type: string
-  /headers/redirect:
+  /redirect:
     get:
       operationId: redirect
       responses:

--- a/schemas/oauth.yaml
+++ b/schemas/oauth.yaml
@@ -4,7 +4,7 @@ info:
   title: OAuth Scopes Sample
   description: A sample API that uses oauth scopes
 paths:
-  /oauth/info:
+  /info:
     get:
       operationId: getInfo
       security:
@@ -17,7 +17,7 @@ paths:
             application/json:
               schema:
                 type: string
-  /oauth/address:
+  /address:
     get:
       operationId: getAddress
       security:

--- a/schemas/validation-min-max.yaml
+++ b/schemas/validation-min-max.yaml
@@ -4,7 +4,7 @@ info:
   title: Min Max Validation
   description: A sample API that demonstrates various min/max validation for both numbers and arrays
 paths:
-  /validation-min-max/colors:
+  /colors:
     get:
       operationId: getColor
       parameters:


### PR DESCRIPTION
MVC Controllers get the full URL embedded by code generation. In order to have a different prefix for each OpenAPI file, this PR adds a  configuration value that allows for a path prefix.

This PR also removes that prefix from the samples that had them added during the testability refactor.

Clients have the base URL passed in (whether TypeScript or C#), so do not need this functionality.