### PR TITLE
Upgrade to .NET 7 and C# 11

### DIFF
--- a/examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample.Oauth/PrincipleStudios.ServerInterfacesExample.Oauth.csproj
+++ b/examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample.Oauth/PrincipleStudios.ServerInterfacesExample.Oauth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample/PrincipleStudios.ServerInterfacesExample.csproj
+++ b/examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample/PrincipleStudios.ServerInterfacesExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/examples/dotnetstandard-client/PrincipleStudios.ClientInterfacesExample/PrincipleStudios.ClientInterfacesExample.csproj
+++ b/examples/dotnetstandard-client/PrincipleStudios.ClientInterfacesExample/PrincipleStudios.ClientInterfacesExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<ApplicationIcon />
 		<OutputType>Exe</OutputType>
 		<StartupObject />

--- a/generators/typescript/PrincipleStudios.OpenApiCodegen.Client.TypeScript/PrincipleStudios.OpenApiCodegen.Client.TypeScript.csproj
+++ b/generators/typescript/PrincipleStudios.OpenApiCodegen.Client.TypeScript/PrincipleStudios.OpenApiCodegen.Client.TypeScript.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/lib/PrincipleStudios.OpenApi.Transformations/PrincipleStudios.OpenApi.Transformations.csproj
+++ b/lib/PrincipleStudios.OpenApi.Transformations/PrincipleStudios.OpenApi.Transformations.csproj
@@ -11,13 +11,13 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
-		<PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Primitives" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
 		<PackageReference Include="SharpYaml" Version="1.6.5" />
 	</ItemGroup>
 </Project>

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/DynamicCompilation.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/DynamicCompilation.cs
@@ -48,7 +48,7 @@ namespace PrincipleStudios.OpenApiCodegen.Client.CSharp
 
             Assert.Empty(diagnostic.Errors);
 
-            var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp9);
+            var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp11);
             var syntaxTrees = entries.Select(e => CSharpSyntaxTree.ParseText(e.SourceText, options: parseOptions, path: e.Key)).ToArray();
 
             string assemblyName = Path.GetRandomFileName();

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test.csproj
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test/PrincipleStudios.OpenApiCodegen.Client.CSharp.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 
@@ -9,9 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test.csproj
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 
@@ -19,7 +19,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/lib/PrincipleStudios.OpenApiCodegen.Json.Extensions.Test/PrincipleStudios.OpenApiCodegen.JsonExtensions.Test.csproj
+++ b/lib/PrincipleStudios.OpenApiCodegen.Json.Extensions.Test/PrincipleStudios.OpenApiCodegen.JsonExtensions.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 
@@ -10,9 +10,10 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.6" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="System.Text.Json" Version="7.0.2" />
+		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/lib/PrincipleStudios.OpenApiCodegen.Json.Extensions/PrincipleStudios.OpenApiCodegen.Json.Extensions.csproj
+++ b/lib/PrincipleStudios.OpenApiCodegen.Json.Extensions/PrincipleStudios.OpenApiCodegen.Json.Extensions.csproj
@@ -25,6 +25,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="6.0.6" />
+		<PackageReference Include="System.Text.Json" Version="7.0.2" />
 	</ItemGroup>
 </Project>

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
@@ -64,7 +64,7 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
             Assert.Equal(expectedName, actual?.text);
         }
 
-        private static IEnumerable<object[]> DetermineSchemaNameList()
+        public static IEnumerable<object[]> DetermineSchemaNameList()
         {
             return new[]
             {

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/DynamicCompilation.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/DynamicCompilation.cs
@@ -53,7 +53,7 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
 
             Assert.Empty(diagnostic.Errors);
 
-            var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp9);
+            var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp11);
             var syntaxTrees = entries.Select(e => CSharpSyntaxTree.ParseText(e.SourceText, options: parseOptions, path: e.Key)).ToArray();
 
             string assemblyName = Path.GetRandomFileName();

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test.csproj
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test.csproj
@@ -10,10 +10,11 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="System.Text.Json" Version="7.0.2" />
+		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/lib/PrincipleStudios.OpenApiCodegen.TestUtils/PrincipleStudios.OpenApiCodegen.TestUtils.csproj
+++ b/lib/PrincipleStudios.OpenApiCodegen.TestUtils/PrincipleStudios.OpenApiCodegen.TestUtils.csproj
@@ -7,11 +7,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.5.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
 		<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
-		<PackageReference Include="Snapshooter.Xunit" Version="0.7.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
With .NET 8 around the corner and the significant improvements that have been made to JSON Serialization in .NET 7, we'll require .NET 7 and C# 11 for future releases.