### PR TITLE
Check MVC Examples during build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git/
+*.snk
+*.local.*
+node_modules/
+**/out.local*/
+**/*.tgz
+.vs/
+**/*.user
+**/*.binlog
+artifacts/

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -158,6 +158,6 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
     - name: Test MVC examples build
-      run: .\examples\dotnetcore-server-interfaces\tooling\build-examples.ps1 -VersionSuffix "sha.$VERSION_SUFFIX" -githubToken $GITHUB_TOKEN
+      run: ./examples/dotnetcore-server-interfaces/tooling/build-examples.ps1 -VersionSuffix "sha.$VERSION_SUFFIX" -githubToken $GITHUB_TOKEN
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -155,9 +155,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ github.ref != 'refs/heads/main' }}
     steps:
     - name: Test MVC examples build
-      if: ${{ github.ref != 'refs/heads/main' }}
       run: .\examples\dotnetcore-server-interfaces\tooling\build-examples.ps1 -VersionSuffix "sha.$VERSION_SUFFIX" -githubToken $GITHUB_TOKEN
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -20,14 +20,14 @@ jobs:
               6.0.x
               7.0.x
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
         registry-url: ${{ github.ref != 'refs/heads/main' && 'https://npm.pkg.github.com/' || 'https://registry.npmjs.org/' }}
         scope: '@principlestudios'
 
     - name: Cache nuget packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.nuget/packages
         # Look to see if there is a cache hit for the corresponding requirements file
@@ -35,7 +35,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget
     - name: Cache node modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: cache-node-modules
       with:
@@ -93,7 +93,7 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage"
     - name: 'Upload Code Coverage'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: code-coverage
         path: ./lib/*/TestResults/*/coverage.cobertura.xml
@@ -157,6 +157,7 @@ jobs:
     needs: build
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
+    - uses: actions/checkout@v3
     - name: Test MVC examples build
       run: ./examples/dotnetcore-server-interfaces/tooling/build-examples.ps1 -VersionSuffix "sha.$VERSION_SUFFIX" -githubToken $GITHUB_TOKEN
       env:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -162,3 +162,4 @@ jobs:
       run: ./examples/dotnetcore-server-interfaces/tooling/build-examples.ps1 -VersionSuffix "sha.$VERSION_SUFFIX" -githubToken $GITHUB_TOKEN
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION_SUFFIX: ${{ github.ref != 'refs/heads/main' && github.sha || '' }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
             dotnet-version: |
               6.0.x

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -149,3 +149,14 @@ jobs:
       env:
         IS_PRERELEASE: ${{ github.ref != 'refs/heads/main' && github.sha || '' }}
         NODE_AUTH_TOKEN: "${{ github.ref == 'refs/heads/main' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}"
+
+    ######################
+    # FINAL VERIFICATIONS
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Test MVC examples build
+      if: ${{ github.ref != 'refs/heads/main' }}
+      run: .\examples\dotnetcore-server-interfaces\tooling\build-examples.ps1 -VersionSuffix "sha.$VERSION_SUFFIX" -githubToken $GITHUB_TOKEN
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -154,6 +154,7 @@ jobs:
     # FINAL VERIFICATIONS
   verify:
     runs-on: ubuntu-latest
+    needs: build
     steps:
     - name: Test MVC examples build
       if: ${{ github.ref != 'refs/heads/main' }}

--- a/examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample.Oauth/Controllers/InfoController.cs
+++ b/examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample.Oauth/Controllers/InfoController.cs
@@ -5,7 +5,7 @@ namespace PrincipleStudios.ServerInterfacesExample.Oauth.Controllers
 {
     public class InfoController : InfoControllerBase
     {
-        protected override Task<GetInfoActionResult> GetInfo(byte[]? data)
+        protected override Task<GetInfoActionResult> GetInfo()
         {
             return Task.FromResult(GetInfoActionResult.Ok(User.Identity!.IsAuthenticated ? $"success as {User.Identity.Name}" : "success"));
         }

--- a/examples/dotnetcore-server-interfaces/tooling/Dockerfile
+++ b/examples/dotnetcore-server-interfaces/tooling/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-dotnet
+WORKDIR /src
+
+COPY ./global.json ./
+COPY ./Directory.Build.props ./
+COPY ./examples/dotnetcore-server-interfaces/dotnetcore-server-interfaces.sln .
+COPY ./examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample/PrincipleStudios.ServerInterfacesExample.csproj ./PrincipleStudios.ServerInterfacesExample/
+COPY ./examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample.Oauth/PrincipleStudios.ServerInterfacesExample.Oauth.csproj ./PrincipleStudios.ServerInterfacesExample.Oauth/
+ARG VersionSuffix
+COPY ./examples/dotnetcore-server-interfaces/tooling/NuGet.Sample.Config ./NuGet.Config
+ARG GitHubToken
+RUN sed -i "s/--your-key--/${GitHubToken}/" NuGet.Config
+RUN dotnet restore -p VersionSuffix=${VersionSuffix} \
+                   -p TreatWarningsAsErrors=true
+
+COPY ./schemas/ ./schemas/
+COPY ./examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample/ ./PrincipleStudios.ServerInterfacesExample/
+COPY ./examples/dotnetcore-server-interfaces/PrincipleStudios.ServerInterfacesExample.Oauth/ ./PrincipleStudios.ServerInterfacesExample.Oauth/
+RUN dotnet build --no-restore -p VersionSuffix=${VersionSuffix}
+

--- a/examples/dotnetcore-server-interfaces/tooling/NuGet.Sample.Config
+++ b/examples/dotnetcore-server-interfaces/tooling/NuGet.Sample.Config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+    <add key="github-ps" value="https://nuget.pkg.github.com/PrincipleStudios/index.json" />
+    </packageSources>
+    <packageSourceCredentials>
+    <github-ps>
+        <!-- The value of "Username" is not specific - it appears to not be validated -->
+        <add key="Username" value="github" />
+        <add key="ClearTextPassword" value="--your-key--" />
+        </github-ps>
+    </packageSourceCredentials>
+</configuration>

--- a/examples/dotnetcore-server-interfaces/tooling/build-examples.ps1
+++ b/examples/dotnetcore-server-interfaces/tooling/build-examples.ps1
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+
+Param(
+    [Parameter(Mandatory)][String] $VersionSuffix,
+    [Parameter()][String] $githubToken
+)
+
+Push-Location "$PSScriptRoot/../../.."
+try {
+    docker build . -f examples/dotnetcore-server-interfaces/tooling/Dockerfile `
+        --build-arg VersionSuffix="$VersionSuffix" `
+        --build-arg GitHubToken="$githubToken"
+} finally {
+    Pop-Location
+}

--- a/examples/dotnetcore-server-interfaces/tooling/build-examples.ps1
+++ b/examples/dotnetcore-server-interfaces/tooling/build-examples.ps1
@@ -10,6 +10,9 @@ try {
     docker build . -f examples/dotnetcore-server-interfaces/tooling/Dockerfile `
         --build-arg VersionSuffix="$VersionSuffix" `
         --build-arg GitHubToken="$githubToken"
+    if ($Global:LASTEXITCODE -ne 0) {
+        throw "Docker build failed with exit code $Global:LASTEXITCODE"
+    }
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
The examples on main do not build due to changes in the schemas. This verifies the example builds using the actual package published to GitHub.