### PR TITLE
Add upgrade path for `Optional<>`

### DIFF
--- a/lib/PrincipleStudios.OpenApi.CSharp/templates/Model.cs
+++ b/lib/PrincipleStudios.OpenApi.CSharp/templates/Model.cs
@@ -46,18 +46,19 @@ namespace PrincipleStudios.OpenApi.CSharp.templates
     );
 
     public record ObjectModel(
-        string description,
-        string className,
-        string? parent,
-        ModelVar[] vars
-    ) : Model(description, className);
+        string Description,
+        string ClassName,
+        string? Parent,
+        ModelVar[] Vars
+    ) : Model(Description, ClassName);
 
     public record ModelVar(
-        string baseName,
-        string dataType,
-        bool nullable,
-        bool isContainer,
-        string name,
-        bool required
+        string BaseName,
+        string DataType,
+        bool Nullable,
+        bool IsContainer,
+        string Name,
+        bool Required,
+        bool Optional
     );
 }

--- a/lib/PrincipleStudios.OpenApi.CSharp/templates/objectmodel.handlebars
+++ b/lib/PrincipleStudios.OpenApi.CSharp/templates/objectmodel.handlebars
@@ -12,7 +12,7 @@ namespace {{this.packageName}}
     /// </summary>
     {{/if}}public partial record {{ClassName}}({{#each Vars}}
         [property: global::System.Text.Json.Serialization.JsonPropertyName("{{BaseName}}")]{{#if Required
-            }}[param: global::System.ComponentModel.DataAnnotations.Required][property: global::System.Text.Json.Serialization.JsonRequiredAttribute]{{else
+            }}[property: global::System.Text.Json.Serialization.JsonRequiredAttribute]{{else
             }}[property: global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]{{/if}}{{!
     data type: }} {{#if Optional}}global::PrincipleStudios.OpenApiCodegen.Json.Extensions.Optional<{{/if}}{{{DataType}}}{{#if Optional}}>?{{/if}}{{!
     name: }} {{Name}}{{#unless @last}}, {{/unless}}{{/each}}

--- a/lib/PrincipleStudios.OpenApi.CSharp/templates/objectmodel.handlebars
+++ b/lib/PrincipleStudios.OpenApi.CSharp/templates/objectmodel.handlebars
@@ -6,16 +6,16 @@
 namespace {{this.packageName}}
 {
     {{#with model}}
-    {{#if description}}/// <summary>
-    /// {{linewrap description "
+    {{#if Description}}/// <summary>
+    /// {{linewrap Description "
     /// "}}
     /// </summary>
-    {{/if}}public partial record {{className}}({{#each vars}}
-        [property: global::System.Text.Json.Serialization.JsonPropertyName("{{baseName}}")]{{#if required
+    {{/if}}public partial record {{ClassName}}({{#each Vars}}
+        [property: global::System.Text.Json.Serialization.JsonPropertyName("{{BaseName}}")]{{#if Required
             }}[param: global::System.ComponentModel.DataAnnotations.Required][property: global::System.Text.Json.Serialization.JsonRequiredAttribute]{{else
             }}[property: global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]{{/if}}{{!
-    data type: }} {{#unless required}}global::PrincipleStudios.OpenApiCodegen.Json.Extensions.Optional<{{/unless}}{{{dataType}}}{{#unless required}}>?{{/unless}}{{!
-    name: }} {{name}}{{#unless @last}}, {{/unless}}{{/each}}
+    data type: }} {{#if Optional}}global::PrincipleStudios.OpenApiCodegen.Json.Extensions.Optional<{{/if}}{{{DataType}}}{{#if Optional}}>?{{/if}}{{!
+    name: }} {{Name}}{{#unless @last}}, {{/unless}}{{/each}}
     );
     {{/with}}
 }

--- a/lib/PrincipleStudios.OpenApi.Transformations/SharedOpenApiExtensions.cs
+++ b/lib/PrincipleStudios.OpenApi.Transformations/SharedOpenApiExtensions.cs
@@ -9,7 +9,7 @@ public static class SharedOpenApiExtensions
 {
     public static bool UseOptionalAsNullable(this OpenApiSchema objectSchema, bool useLegacyByDefault = false)
     {
-        if (!objectSchema.Extensions.TryGetValue("x-PS-Optional-As-Nullable", out var optionalAsNullable) || optionalAsNullable is not Microsoft.OpenApi.Any.OpenApiBoolean { Value: var result })
+        if (!objectSchema.Extensions.TryGetValue("x-ps-optional-as-nullable", out var optionalAsNullable) || optionalAsNullable is not Microsoft.OpenApi.Any.OpenApiBoolean { Value: var result })
             return useLegacyByDefault;
 
         return result;

--- a/lib/PrincipleStudios.OpenApi.Transformations/SharedOpenApiExtensions.cs
+++ b/lib/PrincipleStudios.OpenApi.Transformations/SharedOpenApiExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PrincipleStudios.OpenApi.Transformations;
+
+public static class SharedOpenApiExtensions
+{
+    public static bool UseOptionalAsNullable(this OpenApiSchema objectSchema, bool useLegacyByDefault = false)
+    {
+        if (!objectSchema.Extensions.TryGetValue("x-PS-Optional-As-Nullable", out var optionalAsNullable) || optionalAsNullable is not Microsoft.OpenApi.Any.OpenApiBoolean { Value: var result })
+            return useLegacyByDefault;
+
+        return result;
+    }
+}

--- a/lib/PrincipleStudios.OpenApi.TypeScript/templates/Model.cs
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/templates/Model.cs
@@ -44,12 +44,12 @@ namespace PrincipleStudios.OpenApi.TypeScript.templates
     ) : Model(Description, ClassName);
 
     public record ObjectModel(
-        ImportStatement[] imports,
-        string description,
-        string className,
-        string? parent,
-        ModelVar[] vars
-    ) : Model(description, className);
+        ImportStatement[] Imports,
+        string Description,
+        string ClassName,
+        string? Parent,
+        ModelVar[] Vars
+    ) : Model(Description, ClassName);
 
     public record TypeUnionModel(
         ImportStatement[] Imports,
@@ -66,11 +66,12 @@ namespace PrincipleStudios.OpenApi.TypeScript.templates
     );
 
     public record ModelVar(
-        string baseName,
-        string dataType,
-        bool nullable,
-        bool isContainer,
-        string name,
-        bool required
+        string BaseName,
+        string DataType,
+        bool Nullable,
+        bool IsContainer,
+        string Name,
+        bool Required,
+        bool Optional
     );
 }

--- a/lib/PrincipleStudios.OpenApi.TypeScript/templates/objectmodel.handlebars
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/templates/objectmodel.handlebars
@@ -1,6 +1,6 @@
 {{>partial_header header}}
 {{#with model}}
-{{#each imports}}
+{{#each Imports}}
 import {
 {{#each members}}
     {{{.}}},
@@ -8,21 +8,21 @@ import {
 } from '{{path}}';
 {{/each}}
 
-/**{{#if description}}
- * {{{description}}}{{/if}}
+/**{{#if Description}}
+ * {{{Description}}}{{/if}}
  * @export
- * @interface {{className}}
+ * @interface {{ClassName}}
  */
-export type {{className}} = {{#if parent}}{{{parent}}} &amp; {{/if}}{
+export type {{ClassName}} = {{#if Parent}}{{{Parent}}} &amp; {{/if}}{
 {{!-- {{#if additionalPropertiesType}}
     [key: string]: {{{additionalPropertiesType}}}{{#if vars.Length}} | any{{/if}}; {{! TODO - we really don't want `| any` here... see if TypeScript has an update for us. }}
 {{/if}} --}}
-{{#each vars}}
-    /**{{#if description}}
-     * {{{description}}}{{/if}}
-     * @type {{{dataType}}}
+{{#each Vars}}
+    /**{{#if Description}}
+     * {{{Description}}}{{/if}}
+     * @type {{{DataType}}}
      */
-    {{#if isReadOnly}}readonly {{/if}}{{name}}{{#unless required}}?{{/unless}}: {{{dataType}}};
+    {{#if IsReadOnly}}readonly {{/if}}{{Name}}{{#if Optional}}?{{/if}}: {{{dataType}}};
 {{/each}}
 };
 {{/with}}

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/LegacyOptionalYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/LegacyOptionalYamlShould.cs
@@ -1,0 +1,101 @@
+﻿using PrincipleStudios.OpenApiCodegen.Client.TypeScript.Utils;
+using static PrincipleStudios.OpenApiCodegen.Client.TypeScript.Utils.GenerationUtilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PrincipleStudios.OpenApiCodegen.Client.TypeScript.Integration;
+
+[Collection(CommonDirectoryFixture.CollectionName)]
+public class LegacyOptionalYamlShould
+{
+    private readonly CommonDirectoryFixture commonDirectory;
+
+    public LegacyOptionalYamlShould(CommonDirectoryFixture commonDirectory)
+    {
+        this.commonDirectory = commonDirectory;
+    }
+
+    [Fact]
+    public async Task Support_providing_all_values_for_inline_objects()
+    {
+        var body = new { nullableOnly = 2, optionalOnly = 3, optionalOrNullable = 5 };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional-legacy.yaml", "contrived", new { }, body);
+
+        AssertRequestSuccess(result, "POST", "/contrived", body);
+    }
+
+    [Fact]
+    public async Task Support_providing_values_as_intended_by_yaml_for_inline_objects()
+    {
+        var body = new { nullableOnly = (object?)null };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional-legacy.yaml", "contrived", new { }, body);
+
+        AssertRequestSuccess(result, "POST", "/contrived", body);
+    }
+
+    [Fact]
+    public async Task Support_providing_extra_null_values_for_inline_objects()
+    {
+        var body = new { nullableOnly = (object?)null, optionalOnly = (object?)null, optionalOrNullable = (object?)null };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional-legacy.yaml", "contrived", new { }, body);
+
+        AssertRequestSuccess(result, "POST", "/contrived", body);
+    }
+
+    [Fact]
+    public async Task Not_support_excluding_required_parameters_for_inline_objects()
+    {
+        var body = new { };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional-legacy.yaml", "contrived", new { }, body);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Support_providing_all_values_for_models()
+    {
+        var body = new { errorCode = "foo:bar", errorMessage = "The foo did not bar", referenceCode = "12345" };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional-legacy.yaml", "_Error", body);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Support_providing_values_as_intended_by_yaml_for_models()
+    {
+        var body = new { errorCode = "foo:bar", errorMessage = (object?)null };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional-legacy.yaml", "_Error", body);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Support_providing_extra_null_values_for_models()
+    {
+        var body = new { errorCode = "foo:bar", errorMessage = (object?)null, referenceCode = (object?)null };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional-legacy.yaml", "_Error", body);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Not_support_excluding_required_parameters_for_models()
+    {
+        var body = new { errorCode = "foo:bar" };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional-legacy.yaml", "_Error", body);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+}

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/NullableVsOptionalYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/NullableVsOptionalYamlShould.cs
@@ -1,0 +1,101 @@
+﻿using PrincipleStudios.OpenApiCodegen.Client.TypeScript.Utils;
+using static PrincipleStudios.OpenApiCodegen.Client.TypeScript.Utils.GenerationUtilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PrincipleStudios.OpenApiCodegen.Client.TypeScript.Integration;
+
+[Collection(CommonDirectoryFixture.CollectionName)]
+public class NullableVsOptionalYamlShould
+{
+    private readonly CommonDirectoryFixture commonDirectory;
+
+    public NullableVsOptionalYamlShould(CommonDirectoryFixture commonDirectory)
+    {
+        this.commonDirectory = commonDirectory;
+    }
+
+    [Fact]
+    public async Task Support_providing_all_values_for_inline_objects()
+    {
+        var body = new { nullableOnly = 2, optionalOnly = 3, optionalOrNullable = 5 };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional.yaml", "contrived", new { }, body);
+
+        AssertRequestSuccess(result, "POST", "/contrived", body);
+    }
+
+    [Fact]
+    public async Task Support_providing_values_as_intended_by_yaml_for_inline_objects()
+    {
+        var body = new { nullableOnly = (object?)null };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional.yaml", "contrived", new { }, body);
+
+        AssertRequestSuccess(result, "POST", "/contrived", body);
+    }
+
+    [Fact]
+    public async Task Not_support_providing_extra_null_values_for_inline_objects()
+    {
+        var body = new { nullableOnly = (object?)null, optionalOnly = (object?)null, optionalOrNullable = (object?)null };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional.yaml", "contrived", new { }, body);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Not_support_excluding_required_parameters_for_inline_objects()
+    {
+        var body = new { };
+
+        var result = await commonDirectory.ConvertRequest("nullable-vs-optional.yaml", "contrived", new { }, body);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Support_providing_all_values_for_models()
+    {
+        var body = new { errorCode = "foo:bar", errorMessage = "The foo did not bar", referenceCode = "12345" };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional.yaml", "_Error", body);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Support_providing_values_as_intended_by_yaml_for_models()
+    {
+        var body = new { errorCode = "foo:bar", errorMessage = (object?)null };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional.yaml", "_Error", body);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Not_support_providing_extra_null_values_for_models()
+    {
+        var body = new { errorCode = "foo:bar", errorMessage = (object?)null, referenceCode = (object?)null };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional.yaml", "_Error", body);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Not_support_excluding_required_parameters_for_models()
+    {
+        var body = new { errorCode = "foo:bar" };
+
+        var result = await commonDirectory.CheckModel("nullable-vs-optional.yaml", "_Error", body);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+}

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/ComprehensiveTransformsShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/ComprehensiveTransformsShould.cs
@@ -23,6 +23,7 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
         [InlineData("oauth.yaml")]
         [InlineData("form.yaml")]
         [InlineData("one-of.yaml")]
+        [InlineData("nullable-vs-optional.yaml")]
         [InlineData("nullable-vs-optional-legacy.yaml")]
         [Theory]
         public void Compile_api_documents_included_in_the_TestApp(string name)

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/ComprehensiveTransformsShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/ComprehensiveTransformsShould.cs
@@ -23,6 +23,7 @@ namespace PrincipleStudios.OpenApiCodegen.Server.Mvc
         [InlineData("oauth.yaml")]
         [InlineData("form.yaml")]
         [InlineData("one-of.yaml")]
+        [InlineData("nullable-vs-optional-legacy.yaml")]
         [Theory]
         public void Compile_api_documents_included_in_the_TestApp(string name)
         {

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/LegacyOptionalYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/LegacyOptionalYamlShould.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp;
+
+using static Utilities;
+
+public class LegacyOptionalYamlShould
+{
+    [Fact]
+    public Task Handle_mixed_nullable_optional_with_all_provided() =>
+        TestSingleRequest<LegacyOptional.ContrivedControllerBase.ContrivedActionResult, LegacyOptional.ContrivedRequest>(new(
+            LegacyOptional.ContrivedControllerBase.ContrivedActionResult.Ok(new LegacyOptional.ContrivedResponse(2, 3, 5)),
+            client => client.PostAsync("/nullable-vs-optional-legacy/contrived", JsonContent.Create(new { nullableOnly = 2, optionalOnly = 3, optionalOrNullable = 5 }))
+        )
+        {
+            AssertRequest = (controller, request) =>
+            {
+                Assert.Equal<int?>(2, request.NullableOnly);
+                Assert.Equal<int?>(3, request.OptionalOnly);
+                Assert.Equal<int?>(5, request.OptionalOrNullable);
+            },
+            AssertResponseMessage = VerifyResponse(200, new { nullableOnly = 2, optionalOnly = 3, optionalOrNullable = 5 }),
+        });
+
+    [Fact]
+    public Task Handle_mixed_nullable_optional_with_none_provided() =>
+        TestSingleRequest<LegacyOptional.ContrivedControllerBase.ContrivedActionResult, LegacyOptional.ContrivedRequest>(new(
+            LegacyOptional.ContrivedControllerBase.ContrivedActionResult.Ok(new LegacyOptional.ContrivedResponse(null, null, null)),
+            client => client.PostAsync("/nullable-vs-optional-legacy/contrived", JsonContent.Create(new { nullableOnly = (object?)null, optionalOnly = (object?)null, optionalOrNullable = (object?)null }))
+        )
+        {
+            AssertRequest = (controller, request) =>
+            {
+                Assert.Null(request.NullableOnly);
+                Assert.Null(request.OptionalOnly);
+                Assert.Null(request.OptionalOrNullable);
+            },
+            AssertResponseMessage = VerifyResponse(200, new { nullableOnly = (object?)null }),
+        });
+
+
+
+}

--- a/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/OptionalYamlShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Server.Mvc.Test/TestApp/OptionalYamlShould.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using PrincipleStudios.OpenApiCodegen.Json.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp;
+
+using static Utilities;
+
+public class OptionalYamlShould
+{
+    [Fact]
+    public Task Handle_mixed_nullable_optional_with_all_provided() =>
+        TestSingleRequest<NullableVsOptional.ContrivedControllerBase.ContrivedActionResult, NullableVsOptional.ContrivedRequest>(new(
+            NullableVsOptional.ContrivedControllerBase.ContrivedActionResult.Ok(new NullableVsOptional.ContrivedResponse(2, Optional.Create(3), Optional.Create<int?>(5))),
+            client => client.PostAsync("/nullable-vs-optional/contrived", JsonContent.Create(new { nullableOnly = 2, optionalOnly = 3, optionalOrNullable = 5 }))
+        )
+        {
+            AssertRequest = (controller, request) =>
+            {
+                Assert.True(controller.ModelState.IsValid);
+                Assert.Equal<int?>(2, request.NullableOnly);
+                Assert.Equal<Optional<int>?>(Optional.Create(3), request.OptionalOnly);
+                Assert.Equal<Optional<int?>?>(Optional.Create<int?>(5), request.OptionalOrNullable);
+            },
+            AssertResponseMessage = VerifyResponse(200, new { nullableOnly = 2, optionalOnly = 3, optionalOrNullable = 5 }),
+        });
+
+    [Fact]
+    public Task Disallow_null_values_on_nonnullable_required_properties() =>
+        TestSingleRequest<NullableVsOptional.ContrivedControllerBase.ContrivedActionResult, NullableVsOptional.ContrivedRequest>(new(
+            NullableVsOptional.ContrivedControllerBase.ContrivedActionResult.Unsafe(new BadRequestResult()),
+            client => client.PostAsync("/nullable-vs-optional/contrived", JsonContent.Create(new { nullableOnly = (object?)null, optionalOnly = (object?)null, optionalOrNullable = (object?)null }))
+        )
+        {
+            AssertRequest = (controller, request) =>
+            {
+                Assert.False(controller.ModelState.IsValid);
+            },
+            AssertResponseMessage = VerifyResponse(400),
+        });
+
+    [Fact]
+    public Task Handle_mixed_nullable_optional_with_values_as_intended_by_yaml() =>
+        TestSingleRequest<NullableVsOptional.ContrivedControllerBase.ContrivedActionResult, NullableVsOptional.ContrivedRequest>(new(
+            NullableVsOptional.ContrivedControllerBase.ContrivedActionResult.Ok(new NullableVsOptional.ContrivedResponse(null, null, null)),
+            client => client.PostAsync("/nullable-vs-optional/contrived", JsonContent.Create(new { nullableOnly = (object?)null }))
+        )
+        {
+            AssertRequest = (controller, request) =>
+            {
+                Assert.True(controller.ModelState.IsValid);
+                Assert.Null(request.NullableOnly);
+                Assert.Null(request.OptionalOnly);
+                Assert.Null(request.OptionalOrNullable);
+            },
+            AssertResponseMessage = VerifyResponse(200, new { nullableOnly = (object?)null }),
+        });
+
+    [Fact]
+    public Task Disallow_missing_required_values() =>
+        TestSingleRequest<NullableVsOptional.ContrivedControllerBase.ContrivedActionResult, NullableVsOptional.ContrivedRequest>(new(
+            NullableVsOptional.ContrivedControllerBase.ContrivedActionResult.Unsafe(new BadRequestResult()),
+            client => client.PostAsync("/nullable-vs-optional/contrived", JsonContent.Create(new { }))
+        )
+        {
+            AssertRequest = (controller, request) =>
+            {
+                Assert.False(controller.ModelState.IsValid);
+            },
+            AssertResponseMessage = VerifyResponse(400),
+        });
+
+}

--- a/lib/TestApp/LegacyOptional/Controllers.cs
+++ b/lib/TestApp/LegacyOptional/Controllers.cs
@@ -1,0 +1,19 @@
+﻿namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.LegacyOptional;
+
+public class ContrivedController : ContrivedControllerBase
+{
+    protected override Task<ContrivedActionResult> Contrived(ContrivedRequest contrivedBody)
+    {
+        this.DelegateRequest(contrivedBody);
+        return this.DelegateResponse<ContrivedActionResult>();
+    }
+}
+
+public class SearchController : SearchControllerBase
+{
+    protected override Task<SearchActionResult> Search(SearchRequest searchBody)
+    {
+        this.DelegateRequest(searchBody);
+        return this.DelegateResponse<SearchActionResult>();
+    }
+}

--- a/lib/TestApp/NullableVsOptional/Controllers.cs
+++ b/lib/TestApp/NullableVsOptional/Controllers.cs
@@ -1,0 +1,19 @@
+﻿namespace PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.NullableVsOptional;
+
+public class ContrivedController : ContrivedControllerBase
+{
+    protected override Task<ContrivedActionResult> Contrived(ContrivedRequest contrivedBody)
+    {
+        this.DelegateRequest(contrivedBody);
+        return this.DelegateResponse<ContrivedActionResult>();
+    }
+}
+
+public class SearchController : SearchControllerBase
+{
+    protected override Task<SearchActionResult> Search(SearchRequest searchBody)
+    {
+        this.DelegateRequest(searchBody);
+        return this.DelegateResponse<SearchActionResult>();
+    }
+}

--- a/lib/TestApp/PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -19,6 +19,7 @@
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\form.yaml" Link="Form\form.yaml" Key="Form" PathPrefix="/form" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\one-of.yaml" Link="OneOf\one-of.yaml" Key="OneOf" PathPrefix="/one-of" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional-legacy.yaml" Link="LegacyOptional\nullable-vs-optional-legacy.yaml" Key="LegacyOptional" PathPrefix="/nullable-vs-optional-legacy" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional.yaml" Link="NullableVsOptional\nullable-vs-optional.yaml" Key="NullableVsOptional" PathPrefix="/nullable-vs-optional" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,9 +48,9 @@
       </CodegenCliFiles>
 		<CodegenOutputFiles Include="$(MSBuildProjectDirectory)/generated/**/*.cs" />
     </ItemGroup>
-		
+
 	</Target>
-	
+
     <Target Name="_GenerateServerOpenApiCodegen" DependsOnTargets="_PrepareCodegenFiles" Inputs="%(CodegenCliFiles.FullPath);$(ProjectPath)" Outputs="@(CodegenCliFiles->'$(MSBuildProjectDirectory)/generated/%(Key)/_._')">
         <PropertyGroup>
           <CodegenCliPath>%(CodegenCli.Identity)</CodegenCliPath>

--- a/lib/TestApp/PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/PrincipleStudios.OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -18,6 +18,7 @@
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\oauth.yaml" Link="OAuth\oauth.yaml" Key="OAuth" PathPrefix="/oauth" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\form.yaml" Link="Form\form.yaml" Key="Form" PathPrefix="/form" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\one-of.yaml" Link="OneOf\one-of.yaml" Key="OneOf" PathPrefix="/one-of" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional-legacy.yaml" Link="LegacyOptional\nullable-vs-optional-legacy.yaml" Key="LegacyOptional" PathPrefix="/nullable-vs-optional-legacy" />
   </ItemGroup>
 
   <ItemGroup>

--- a/openapi-codegen.sln
+++ b/openapi-codegen.sln
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrincipleStudios.OpenApiCod
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Server.Mvc", "Server.Mvc", "{C800B3FC-9890-4858-B2F3-4DA9B6957415}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Client.TypeScriptRxJs", "Client.TypeScriptRxJs", "{6425AC08-57C0-4453-A78A-537E9514CE7B}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Client.TypeScript", "Client.TypeScript", "{6425AC08-57C0-4453-A78A-537E9514CE7B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrincipleStudios.OpenApiCodegen.Client.TypeScript", "generators\typescript\PrincipleStudios.OpenApiCodegen.Client.TypeScript\PrincipleStudios.OpenApiCodegen.Client.TypeScript.csproj", "{C0E47301-8CB1-44F6-8321-BCB9C09219BB}"
 EndProject

--- a/schemas/nullable-vs-optional-legacy.yaml
+++ b/schemas/nullable-vs-optional-legacy.yaml
@@ -7,7 +7,7 @@ components:
   schemas:
     Error:
       type: object
-      x-PS-Optional-As-Nullable: true
+      x-ps-optional-as-nullable: true
       required:
         - errorCode
         - errorMessage
@@ -25,7 +25,7 @@ paths:
           application/json:
             schema:
               type: object
-              x-PS-Optional-As-Nullable: true
+              x-ps-optional-as-nullable: true
               required:
                 - name
               properties:
@@ -42,7 +42,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  x-PS-Optional-As-Nullable: true
+                  x-ps-optional-as-nullable: true
                   required:
                     - id
                     - name
@@ -66,7 +66,7 @@ paths:
           application/json:
             schema:
               type: object
-              x-PS-Optional-As-Nullable: true
+              x-ps-optional-as-nullable: true
               required:
                 - nullableOnly
               properties:
@@ -80,7 +80,7 @@ paths:
             application/json:
               schema:
                 type: object
-                x-PS-Optional-As-Nullable: true
+                x-ps-optional-as-nullable: true
                 required:
                   - nullableOnly
                 properties:

--- a/schemas/nullable-vs-optional-legacy.yaml
+++ b/schemas/nullable-vs-optional-legacy.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   version: 1.0.0
-  title: Nullable vs Optional
+  title: Nullable vs Optional (Legacy)
   description: A sample API that demonstrates the difference between nullable and optional properties
 components:
   schemas:

--- a/schemas/nullable-vs-optional-legacy.yaml
+++ b/schemas/nullable-vs-optional-legacy.yaml
@@ -1,0 +1,89 @@
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: Nullable vs Optional
+  description: A sample API that demonstrates the difference between nullable and optional properties
+components:
+  schemas:
+    Error:
+      type: object
+      x-PS-Optional-As-Nullable: true
+      required:
+        - errorCode
+        - errorMessage
+      properties:
+        errorCode: { type: string }
+        errorMessage: { type: string, nullable: true }
+        referenceCode: { type: string }
+paths:
+  /search:
+    post:
+      operationId: search
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              x-PS-Optional-As-Nullable: true
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                department:
+                  type: string
+      responses:
+        '200':
+          description: List of results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  x-PS-Optional-As-Nullable: true
+                  required:
+                    - id
+                    - name
+                    - department
+                  properties:
+                    id: { type: string }
+                    name: { type: string }
+                    department: { type: string, nullable: true }
+        '400':
+          description: An error occurred processing the request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /contrived:
+    post:
+      operationId: contrived
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              x-PS-Optional-As-Nullable: true
+              required:
+                - nullableOnly
+              properties:
+                nullableOnly: { type: integer, nullable: true }
+                optionalOnly: { type: integer }
+                optionalOrNullable: { type: integer, nullable: true }
+      responses:
+        '200':
+          description: Contrived response
+          content:
+            application/json:
+              schema:
+                type: object
+                x-PS-Optional-As-Nullable: true
+                required:
+                  - nullableOnly
+                properties:
+                  nullableOnly: { type: integer, nullable: true }
+                  optionalOnly: { type: integer }
+                  optionalOrNullable: { type: integer, nullable: true }


### PR DESCRIPTION
Introduces new `x-ps-optional-as-nullable` extension on object schemas to use legacy behavior for non-required properties.