### PR TITLE
Fix TypeScript generation for objects within inline arrays

### DIFF
--- a/lib/PrincipleStudios.OpenApi.TypeScript/Templates/arraymodel.handlebars
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/Templates/arraymodel.handlebars
@@ -13,5 +13,5 @@ import {
  * @export
  */
 export type {{ClassName}} =
-    Array<{{Item}}>;
+    Array<{{{Item}}}>;
 {{/with}}

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/InlineArrayObjectShould.cs
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/Integration/InlineArrayObjectShould.cs
@@ -1,0 +1,30 @@
+﻿using PrincipleStudios.OpenApiCodegen.Client.TypeScript.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PrincipleStudios.OpenApiCodegen.Client.TypeScript.Integration;
+
+[Collection(CommonDirectoryFixture.CollectionName)]
+public class InlineArrayObjectShould
+{
+    private readonly CommonDirectoryFixture commonDirectory;
+
+    public InlineArrayObjectShould(CommonDirectoryFixture commonDirectory)
+    {
+        this.commonDirectory = commonDirectory;
+    }
+
+    [Fact]
+    public async Task Allow_objects_inside_inline_arrays()
+    {
+        var body = new[] { new { id = "baadf00d" } };
+
+        var result = await commonDirectory.CheckModel("github-issue-42.yaml", "SomeArray", body);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+}

--- a/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/tsconfig.testing.json
+++ b/lib/PrincipleStudios.OpenApiCodegen.Client.TypeScript.Test/tsconfig.testing.json
@@ -5,6 +5,7 @@
             "DOM"
         ],
         "strict": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "noEmit": true
     }
 }

--- a/schemas/github-issue-42.yaml
+++ b/schemas/github-issue-42.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: TypeScript array model escapes inline objects
+  description: "See GitHub issue #42"
+paths:
+  /:
+    get:
+      operationId: testPath
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeArray'
+components:
+  schemas:
+    SomeArray:
+      type: array
+      items:
+        type: object
+        properties:
+          id: { type: string }


### PR DESCRIPTION
Using handlebars `{{{Item}}}` resolved the issue, but the tests weren't detecting the invalid generated code.