### PR TITLE
Remove "satisfies" to support older versions of TS (like next.js)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
 		<OpenApiJsonExtensionsVersion>0.14.0</OpenApiJsonExtensionsVersion>
 		<OpenApiMvcServerVersion>0.14.0</OpenApiMvcServerVersion>
 		<OpenApiCSharpClientVersion>0.14.0</OpenApiCSharpClientVersion>
-		<OpenApiTypeScriptClientVersion>0.6.0</OpenApiTypeScriptClientVersion>
+		<OpenApiTypeScriptClientVersion>0.6.1</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.6.0</OpenApiTypeScriptRxjsClientVersion>
 		<!-- Should be incremented anytime one of the internal libraries changes -->
 		<SharedAnalyzerLibrariesVersion>0.4.0</SharedAnalyzerLibrariesVersion>

--- a/generators/typescript/PrincipleStudios.OpenApiCodegen.Client.TypeScript/Templates/operation.handlebars
+++ b/generators/typescript/PrincipleStudios.OpenApiCodegen.Client.TypeScript/Templates/operation.handlebars
@@ -175,7 +175,7 @@ export function constructResponse(res: AdapterResponseArgs) {
     }) as Responses;
 }
 
-export const conversion = {
+export const conversion: RequestConversion<typeof method, UrlParams, RequestParams, {{#if RequestBodies.length}}RequestBodies{{else}}{}{{/if}}, Responses, typeof callType> = {
     name: '{{{Name}}}',
     method,
     url: constructUrl,
@@ -185,6 +185,6 @@ export const conversion = {
     {{/if}}
     request: constructRequest,
     response: constructResponse,
-} as const satisfies RequestConversion<typeof method, UrlParams, RequestParams, {{#if RequestBodies.length}}RequestBodies{{else}}{}{{/if}}, Responses, typeof callType>;
+};
 
 {{/with}}


### PR DESCRIPTION
See vercel/next.js#43799