### PR TITLE
Add barrel file for TypeScript models

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
 		<OpenApiJsonExtensionsVersion>0.14.0</OpenApiJsonExtensionsVersion>
 		<OpenApiMvcServerVersion>0.14.2</OpenApiMvcServerVersion>
 		<OpenApiCSharpClientVersion>0.14.2</OpenApiCSharpClientVersion>
-		<OpenApiTypeScriptClientVersion>0.6.3</OpenApiTypeScriptClientVersion>
+		<OpenApiTypeScriptClientVersion>0.7.0</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.6.0</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.6.0</OpenApiTypeScriptMswVersion>
 		<OpenApiTypeScriptFetchVersion>0.7.0</OpenApiTypeScriptFetchVersion>

--- a/lib/PrincipleStudios.OpenApi.TypeScript/HandlebarsTemplateProcess.cs
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/HandlebarsTemplateProcess.cs
@@ -77,6 +77,19 @@ namespace PrincipleStudios.OpenApi.TypeScript
             }
         }
 
+        public static string ProcessModelBarrelFile(
+            ModelBarrelFile modelBarrelFile,
+            IHandlebars? handlebars = null
+        )
+        {
+            handlebars ??= CreateHandlebars();
+            var dict = ToDictionary(modelBarrelFile);
+
+            using var sr = new StringWriter();
+            handlebars.Configuration.RegisteredTemplates["modelBarrelFile"](sr, dict);
+            return sr.ToString();
+        }
+
         public static IDictionary<string, object?> ToDictionary<T>(T model)
         {
             var result = model == null ? JValue.CreateNull() : JToken.FromObject(model);

--- a/lib/PrincipleStudios.OpenApi.TypeScript/Templates/ModelBarrelFile.cs
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/Templates/ModelBarrelFile.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PrincipleStudios.OpenApi.TypeScript.Templates;
+
+public record ModelBarrelFileTemplate(
+    PartialHeader Header,
+
+    ModelBarrelFile Model
+);
+
+public record ExportMember(
+    string MemberName,
+    bool IsType
+);
+
+public record ExportStatement(
+    ExportMember[] Members,
+    string Path
+);
+
+public record ModelBarrelFile(PartialHeader Header, ExportStatement[] Exports);

--- a/lib/PrincipleStudios.OpenApi.TypeScript/Templates/modelBarrelFile.handlebars
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/Templates/modelBarrelFile.handlebars
@@ -1,0 +1,8 @@
+{{>partial_header Header}}
+{{#each Exports}}
+export {
+{{#each Members}}
+    {{#if IsType}}type {{/if}}{{{MemberName}}},
+{{/each}}
+} from '{{Path}}';
+{{/each}}

--- a/lib/PrincipleStudios.OpenApi.TypeScript/TypeScriptSchemaSourceResolverExtensions.cs
+++ b/lib/PrincipleStudios.OpenApi.TypeScript/TypeScriptSchemaSourceResolverExtensions.cs
@@ -9,6 +9,20 @@ namespace PrincipleStudios.OpenApi.TypeScript
 {
     public static class TypeScriptSchemaSourceResolverExtensions
     {
+        public static IEnumerable<Templates.ExportStatement> GetExportStatements(this ISchemaSourceResolver<InlineDataType> sourceResolver, IEnumerable<OpenApiSchema> schemasReferenced, TypeScriptSchemaOptions options, string path)
+        {
+            // FIXME: this is very hacked together; this accesses the "inline" data type to determine what should be exported
+            return from entry in schemasReferenced
+                   let t = sourceResolver.ToInlineDataType(entry)()
+                   from import in t.Imports
+                   from refName in new[] { new Templates.ExportMember(import.Member, IsType: true) }.Concat(GetAdditionalModuleMembers(t, entry, options))
+                   let fileName = import.File
+                   group refName by fileName into imports
+                   let nodePath = imports.Key.ToNodePath(path)
+                   orderby nodePath
+                   select new Templates.ExportStatement(imports.Distinct().OrderBy(a => a.MemberName).ToArray(), nodePath);
+        }
+
 
         public static IEnumerable<Templates.ImportStatement> GetImportStatements(this ISchemaSourceResolver<InlineDataType> sourceResolver, IEnumerable<OpenApiSchema> schemasReferenced, IEnumerable<OpenApiSchema> excludedSchemas, string path)
         {
@@ -22,6 +36,19 @@ namespace PrincipleStudios.OpenApi.TypeScript
                    let nodePath = imports.Key.ToNodePath(path)
                    orderby nodePath
                    select new Templates.ImportStatement(imports.Distinct().OrderBy(a => a).ToArray(), nodePath);
+        }
+
+        private static IEnumerable<Templates.ExportMember> GetAdditionalModuleMembers(InlineDataType t, OpenApiSchema schema, TypeScriptSchemaOptions options)
+        {
+            switch (schema)
+            {
+                case { Enum: { Count: > 0 } }:
+                    yield return new Templates.ExportMember(
+                        TypeScriptNaming.ToPropertyName(t.text, options.ReservedIdentifiers()),
+                        IsType: false
+                    );
+                    break;
+            }
         }
 
         public static string ToNodePath(this string path, string fromPath)


### PR DESCRIPTION
This adds the `type` keyword for forwarding the export to accommodate the `isolatedModules` typescript flag. I believe this is in the latest version of NextJS (unlike the `satisfies` operator I used previously.) See the example, which is for the `Option` schema in `enum.yaml`:

```typescript
export {
    option,
    type Option,
} from './Option';
```