### PR TITLE
Remove unneeded task

### DIFF
--- a/eng/npm.targets
+++ b/eng/npm.targets
@@ -54,9 +54,6 @@
     </Target>
 
     <Target Name="NpmPack" BeforeTargets="Publish" DependsOnTargets="_LoadPackageJson;NodeBuild" Inputs="@(NpmPackagedFiles)" Outputs="$(PackageOutputPath)$(NpmPackageNormalizedName)-$(Version).tgz">
-        <JsonPeek ContentPath="package.json" Query="$.version">
-            <Output TaskParameter="Result" ItemName="OriginalNpmPackageVersion" />
-        </JsonPeek>
         <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(Version)" IgnoreExitCode="true" />
         <MakeDir Directories="$(PackageOutputPath)"/>
         <Exec WorkingDirectory="$(ProjectDir)" Command="npm pack --pack-destination $(PackageOutputPath)" />


### PR DESCRIPTION
JsonPeek records to an Item (not a Property) - line 43 already copies the item into a property in a previous step.